### PR TITLE
fix/readme-flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ Running on a Linux eg. server, simply run the `./prowl` command.
 
 *prowl* supports a few command line parameters:
 
-* `-port [port_number]` lets you set the port number the server should listen on. Default is `5000`.
-* `-protected` set it to require a query parameter with a _secret key_ (the key has to be set, either with the `-secret` flag or the `PROWL_SECRET` environment variable).
+* `-port [port_number]` lets you set the port number the server should listen on. Default is `5001`.
+* `-protect` set it to require a query parameter with a _secret key_ (the key has to be set, either with the `-secret` flag or the `PROWL_SECRET` environment variable).
 * `-secret [secret_key]` is to set the secret to use if you use the `-protected` flag.

--- a/doc_test.go
+++ b/doc_test.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestReadmeMentionsCurrentFlags(t *testing.T) {
+	content, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("failed to read README.md: %v", err)
+	}
+
+	readme := string(content)
+	if !strings.Contains(readme, "`-protect`") {
+		t.Fatalf("README.md should mention the -protect flag")
+	}
+	if !strings.Contains(readme, "Default is `5001`") {
+		t.Fatalf("README.md should mention default port 5001")
+	}
+}


### PR DESCRIPTION
Align README flags and defaults with the code; add a small doc check test.